### PR TITLE
Fix plugin-validator installation path

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Lint plugin
         run: |
           git clone https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/cmd/plugincheck
+          pushd ./plugin-validator/pkg/cmd/plugincheck
           go install
           popd
           plugincheck ${{ steps.metadata.outputs.archive }}


### PR DESCRIPTION
https://github.com/grafana/plugin-validator had a refactor with some paths changes 6 days ago and this wasn't updated, causing the action to fail